### PR TITLE
:necktie: made libraryConfig more flexible

### DIFF
--- a/integrations/analytics-bigquery/docs/README.md
+++ b/integrations/analytics-bigquery/docs/README.md
@@ -70,8 +70,7 @@ app.configure({
       datasetId: '<YOUR-DATASET-ID>',
       tableId: '<YOUR-TABLE-ID>', 
       libraryConfig: {
-        projectId: serviceAccount.project_id,
-        keyFilename: './serviceAccount.json',
+        credentials: serviceAccount,
       },
       // ...
     }),
@@ -129,14 +128,28 @@ import serviceAccount from './serviceAccount.json';
 
 new BigQueryAnalytics({
   libraryConfig: {
-    projectId: serviceAccount.project_id,
-    keyFilename: './src/serviceAccount.json',
+    credentials: serviceAccount,
     // ...
   },
   // ...
 }),
 ```
+or:
+```typescript
+import { BigQueryAnalytics } from '@jovotech/analytics-bigquery';
+import serviceAccount from './serviceAccount.json';
+// ...
 
+new BigQueryAnalytics({
+  libraryConfig: {
+    projectId: serviceAccount.project_id,
+    keyFilename: './serviceAccount.json',
+  },
+  // ...
+}),
+```
+
+- `credentials`: imported service account JSON (including project_id)
 - `projectId`: BigQuery project id.
 - `keyFilename`: Path to the service account JSON file.
 - For more properties, see the [official reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest/bigquery/bigqueryoptions).

--- a/integrations/analytics-bigquery/src/BigQueryAnalytics.ts
+++ b/integrations/analytics-bigquery/src/BigQueryAnalytics.ts
@@ -61,18 +61,6 @@ export class BigQueryAnalytics extends AnalyticsPlugin<BigQueryAnalyticsPluginCo
       });
     }
 
-    if (!this.config.libraryOptions?.keyFilename) {
-      throw new JovoError({
-        message: `Can not send request to BigQuery. Key-Filename is missing.`,
-      });
-    }
-
-    if (!this.config.libraryOptions?.projectId) {
-      throw new JovoError({
-        message: `Can not send request to BigQuery. Project-ID is missing.`,
-      });
-    }
-
     if (typeof this.config.logging === 'boolean') {
       const flag = this.config.logging;
 


### PR DESCRIPTION
## Proposed Changes

This change tries to open the `libraryConfig` to be used more flexibly by not throwing errors, if e. g. credentials are provided via the `credentials` property instead of the `keyFilename` property. 
## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
